### PR TITLE
Allow for no _atom_type_symbol in CIF when dispersion is not considered

### DIFF
--- a/test/SiO2_mp-7000_conventional_standard.cif
+++ b/test/SiO2_mp-7000_conventional_standard.cif
@@ -1,0 +1,35 @@
+# generated using pymatgen
+data_SiO2
+_symmetry_space_group_name_H-M   'P 1'
+_cell_length_a   5.02150261
+_cell_length_b   5.02150261
+_cell_length_c   5.51057000
+_cell_angle_alpha   90.00000000
+_cell_angle_beta   90.00000000
+_cell_angle_gamma   120.00000000
+_symmetry_Int_Tables_number   1
+_chemical_formula_structural   SiO2
+_chemical_formula_sum   'Si3 O6'
+_cell_volume   120.33571438
+_cell_formula_units_Z   3
+loop_
+ _symmetry_equiv_pos_site_id
+ _symmetry_equiv_pos_as_xyz
+  1  'x, y, z'
+loop_
+ _atom_site_type_symbol
+ _atom_site_label
+ _atom_site_symmetry_multiplicity
+ _atom_site_fract_x
+ _atom_site_fract_y
+ _atom_site_fract_z
+ _atom_site_occupancy
+  Si  Si0  1  0.52369500  0.52369500  0.00000000  1
+  Si  Si1  1  0.00000000  0.47630500  0.66666667  1
+  Si  Si2  1  0.47630500  0.00000000  0.33333333  1
+  O  O3  1  0.25609400  0.41485400  0.79454300  1
+  O  O4  1  0.58514600  0.84124000  0.12787633  1
+  O  O5  1  0.15876000  0.74390600  0.46120967  1
+  O  O6  1  0.41485400  0.25609400  0.20545700  1
+  O  O7  1  0.74390600  0.15876000  0.53879033  1
+  O  O8  1  0.84124000  0.58514600  0.87212367  1

--- a/test/test_structure.py
+++ b/test/test_structure.py
@@ -40,6 +40,12 @@ class test_cifread(unittest.TestCase):
         self.assertEqual([8.5312,4.8321,10.125,90.00,92.031,90.00],
                           mylist.atomlist.cell)
 
+    def test_cifread_atom_type_symbol_lacking(self):
+        mylist =  structure.build_atomlist()
+        try:
+            mylist.CIFread('SiO2_mp-7000_conventional_standard.cif')
+        except:
+            self.fail("CIFread() failed to read CIF lacking _atom_type_symbol")
 
 class test_structurefactor(unittest.TestCase):
     def test_sfcalc(self):  ## test method names begin 'test*'

--- a/xfab/structure.py
+++ b/xfab/structure.py
@@ -348,15 +348,22 @@ class build_atomlist:
                                    cifblk['_symmetry_space_group_name_H-M'])
 
         # Dispersion factors
-        for i in range(len(cifblk['_atom_type_symbol'])):
-            try:
-                self.atomlist.dispersion[cifblk['_atom_type_symbol'][i].upper()] =\
-                    [self.remove_esd(cifblk['_atom_type_scat_dispersion_real'][i]),
-                     self.remove_esd(cifblk['_atom_type_scat_dispersion_imag'][i])]
-            except:
-                self.atomlist.dispersion[cifblk['_atom_type_symbol'][i].upper()] = None
+        if '_atom_type_symbol' in list(cifblk.keys()):
+            for i in range(len(cifblk['_atom_type_symbol'])):
+                try:
+                    self.atomlist.dispersion[cifblk['_atom_type_symbol'][i].upper()] =\
+                        [self.remove_esd(cifblk['_atom_type_scat_dispersion_real'][i]),
+                        self.remove_esd(cifblk['_atom_type_scat_dispersion_imag'][i])]
+                except:
+                    self.atomlist.dispersion[cifblk['_atom_type_symbol'][i].upper()] = None
+                    logging.warning('No dispersion factors for %s in cif file - set to zero'\
+                                        %cifblk['_atom_type_symbol'][i])
+        else:
+            logging.warning('No _atom_type_symbol found in CIF')
+            for i in range(len(cifblk['_atom_site_type_symbol'])):
+                self.atomlist.dispersion[cifblk['_atom_site_type_symbol'][i].upper()] = None
                 logging.warning('No dispersion factors for %s in cif file - set to zero'\
-                                    %cifblk['_atom_type_symbol'][i])
+                                        %cifblk['_atom_site_type_symbol'][i])
 
         for i in range(len(cifblk['_atom_site_type_symbol'])):
             label = cifblk['_atom_site_label'][i]


### PR DESCRIPTION
This seems a bit hacky, but as far as I can understand the _atom_type_symbol is only used if dispersion information is in the cif.

Cheers
Axel