### PR TITLE
Make xfab logging module level rather than root - for traceability and control

### DIFF
--- a/test/test_structure.py
+++ b/test/test_structure.py
@@ -67,7 +67,6 @@ class test_structurefactor(unittest.TestCase):
                                                  mylist.atomlist.dispersion)
             F2 = Fr**2 + Fi**2
             reldif = F2/eval(fcf['_refln_F_squared_calc'][i])-1
-            print(i, reldif, F2)
             if F2 > 10: # Only compare those with an F^2 larger than ten 
                         # to avoid that the very weak reflections which
                         # have a relative difference that are slightly larger

--- a/xfab/parameters.py
+++ b/xfab/parameters.py
@@ -24,6 +24,9 @@ Class to handle groups of parameters to be saved in and out
 of files and edited in guis with the fixed/varied info etc
 """
 
+from xfab import xfab_logging
+logger = xfab_logging.get_module_level_logger(__name__)
+
 class par:
     """
     Represents a thing which can vary
@@ -66,7 +69,6 @@ class par:
                 self.can_vary,
                 self.stepsize ]
 
-import logging 
 class parameters:
     """
     Class to hold a set of named parameters
@@ -159,10 +161,10 @@ class parameters:
         for k,v in list(self.parameters.items()):
             if hasattr(other,k):
                 var = getattr(other,k)
-                logging.debug("setting: %s.%s from %s to %s"%(other,k,var,v))
+                logger.debug("setting: %s.%s from %s to %s"%(other,k,var,v))
                 setattr(other,k,v)
             else:
-                logging.debug("error: %s has no attribute %s, ignoring"%
+                logger.debug("error: %s has no attribute %s, ignoring"%
                               (other,k))
 
     def saveparameters(self,filename):

--- a/xfab/parameters.py
+++ b/xfab/parameters.py
@@ -149,10 +149,10 @@ class parameters:
         for k,v in list(self.parameters.items()):
             if hasattr(other,k):
                 var = getattr(other,k)
-                print("setting: pars[%s] from %s to %s"%(k,v,var))
+                logger.debug("setting: pars[%s] from %s to %s"%(k,v,var))
                 self.parameters[k]=var
             else:
-                print("error: %s has no attribute %s, ignoring"%(other,k))
+                logger.debug("error: %s has no attribute %s, ignoring"%(other,k))
 
     def update_other(self,other):
         """
@@ -189,7 +189,7 @@ class parameters:
                 name=name.replace("-","_")
                 self.parameters[name]=value
             except ValueError:
-                print("Failed to read:",line)
+                logger.error("Failed to read:%s"%(line))
         self.dumbtypecheck()
 
     def dumbtypecheck(self):

--- a/xfab/structure.py
+++ b/xfab/structure.py
@@ -4,7 +4,6 @@ and calculation of form factors and structure factors etc.
 """
 
 from __future__ import absolute_import
-from re import L
 import numpy as n
 
 from xfab import tools

--- a/xfab/structure.py
+++ b/xfab/structure.py
@@ -4,13 +4,16 @@ and calculation of form factors and structure factors etc.
 """
 
 from __future__ import absolute_import
+from re import L
 import numpy as n
-import logging
 
 from xfab import tools
 from xfab import sg
 from xfab import atomlib
 from six.moves import range
+
+from xfab import xfab_logging
+logger = xfab_logging.get_module_level_logger(__name__)
 
 def StructureFactor(hkl, ucell, sgname, atoms, disper = None):
     """
@@ -45,7 +48,7 @@ def StructureFactor(hkl, ucell, sgname, atoms, disper = None):
         else:
             expij = 1
             atoms[i].adp = 'Uiso'
-            #logging.error("wrong no of elements in atomlist")
+            #logger.error("wrong no of elements in atomlist")
 
         # Atomic form factors
         f = FormFactor(atoms[i].atomtype, stl)
@@ -227,7 +230,7 @@ class build_atomlist:
         try:
             cf = ReadCif(ciffile)
         except:
-            logging.error('File %s could not be accessed' %ciffile)        
+            logger.error('File %s could not be accessed' %ciffile)        
 
         if cifblkname == None:   
             #Try to guess blockname                                                     
@@ -236,10 +239,10 @@ class build_atomlist:
                 if len(blocks) == 2 and 'global' in blocks:
                     cifblkname = blocks[abs(blocks.index('global') - 1)]
                 else:
-                    logging.error('More than one possible data set:')
-                    logging.error('The following data block names are in the file:')
+                    logger.error('More than one possible data set:')
+                    logger.error('The following data block names are in the file:')
                     for block in blocks:
-                        logging.error(block)
+                        logger.error(block)
                     raise Exception
             else:
                 # Only one available
@@ -248,7 +251,7 @@ class build_atomlist:
         try:
             self.cifblk = cf[cifblkname]
         except:
-            logging.error('Block - %s - not found in %s' % (cifblkname, ciffile))
+            logger.error('Block - %s - not found in %s' % (cifblkname, ciffile))
             raise IOError
         return self.cifblk
 
@@ -261,7 +264,7 @@ class build_atomlist:
         try:
             text = open(pdbfile, 'r').readlines()
         except:
-            logging.error('File %s could not be accessed' % pdbfile)
+            logger.error('File %s could not be accessed' % pdbfile)
 
 
         for i in range(len(text)):
@@ -352,13 +355,13 @@ class build_atomlist:
                         self.remove_esd(cifblk['_atom_type_scat_dispersion_imag'][i])]
                 except:
                     self.atomlist.dispersion[cifblk['_atom_type_symbol'][i].upper()] = None
-                    logging.warning('No dispersion factors for %s in cif file - set to zero'\
+                    logger.warning('No dispersion factors for %s in cif file - set to zero'\
                                         %cifblk['_atom_type_symbol'][i])
         else:
-            logging.warning('No _atom_type_symbol found in CIF')
+            logger.warning('No _atom_type_symbol found in CIF')
             for i in range(len(cifblk['_atom_site_type_symbol'])):
                 self.atomlist.dispersion[cifblk['_atom_site_type_symbol'][i].upper()] = None
-                logging.warning('No dispersion factors for %s in cif file - set to zero'\
+                logger.warning('No dispersion factors for %s in cif file - set to zero'\
                                         %cifblk['_atom_site_type_symbol'][i])
 
         for i in range(len(cifblk['_atom_site_type_symbol'])):

--- a/xfab/symmetry.py
+++ b/xfab/symmetry.py
@@ -10,6 +10,9 @@ from numpy.linalg import det, inv
 from xfab import tools
 from six.moves import range
 
+from xfab import xfab_logging
+logger = xfab_logging.get_module_level_logger(__name__)
+
 
 def Umis(umat_1, umat_2, crystal_system):
     """    
@@ -33,7 +36,7 @@ def Umis(umat_1, umat_2, crystal_system):
         g_vector = dot(umat_2, transpose(dot(umat_1, rot[k])))
         detg = det(g_vector)
         if detg < 0.9999 or detg > 1.0001:
-            print('mistake %f' % detg)
+            logger.debug('mistake %f' % detg)
         else:
             length = (g_vector.diagonal().sum()-1.)/2.
             if abs(length) > 1.00000000:
@@ -56,7 +59,7 @@ def add_perm(hkl, crystal_system):
     nperm = perm.shape[0]
     
     for k in range(nperm):
-        print(dot(perm[k],hkl))
+        logger.debug(dot(perm[k],hkl))
 
         
 def add_rot(umat, crystal_system):
@@ -69,7 +72,7 @@ def add_rot(umat, crystal_system):
     nrot = rot.shape[0]
     
     for k in range(nrot):
-        print(dot(umat, rot[k]))
+        logger.debug(dot(umat, rot[k]))
 
         
 def permutations(crystal_system):

--- a/xfab/tools.py
+++ b/xfab/tools.py
@@ -10,6 +10,8 @@ from math import degrees
 from six.moves import range
 from xfab import checks
 
+from xfab import xfab_logging
+logger = xfab_logging.get_module_level_logger(__name__)
 
 def find_omega_general(g_w, twoth, w_x, w_y):
     """
@@ -1128,7 +1130,7 @@ def genhkl_base(unit_cell, sysconditions, sintlmin, sintlmax, crystal_system='tr
 
     # Triclinic : Laue group -1
     if Laue_class == '-1':
-        print('Laue class : -1', unit_cell)
+        logger.debug('Laue class : -1 %s'%unit_cell)
         segm = n.array([[[ 0, 0,  0], [ 1, 0, 0], [ 0, 1, 0], [ 0, 0,  1]],
                         [[-1, 0,  1], [-1, 0, 0], [ 0, 1, 0], [ 0, 0,  1]],
                         [[-1, 1,  0], [-1, 0, 0], [ 0, 1, 0], [ 0, 0, -1]],
@@ -1142,7 +1144,7 @@ def genhkl_base(unit_cell, sysconditions, sintlmin, sintlmax, crystal_system='tr
     # Monoclinic : Laue group 2/M 
     # unique b        
     if Laue_class == '2/m':
-        print('Laue class : 2/m', unit_cell)
+        logger.debug('Laue class : 2/m %s'%unit_cell)
         segm = n.array([[[ 0, 0,  0], [ 1, 0, 0], [ 0, 1, 0], [ 0, 0,  1]],
                         [[-1, 0,  1], [-1, 0, 0], [ 0, 1, 0], [ 0, 0,  1]]])
 
@@ -1177,31 +1179,31 @@ def genhkl_base(unit_cell, sysconditions, sintlmin, sintlmax, crystal_system='tr
 
     # Laue group : -3M1
     if Laue_class == '-3m1':
-        print('Laue class : -3m1 (hex)', unit_cell)
+        logger.debug('Laue class : -3m1 (hex) %s'%unit_cell)
         if unit_cell[4]==unit_cell[5]:
-            print('#############################################################')
-            print('# Are you using a rhombohedral cell in a hexagonal setting? #')
-            print('#############################################################')
+            logger.debug('#############################################################')
+            logger.debug('# Are you using a rhombohedral cell in a hexagonal setting? #')
+            logger.debug('#############################################################')
         segm = n.array([[[ 0, 0,  0], [ 1, 0, 0], [ 1, 1, 0], [ 0, 0,  1]],
                         [[ 0, 1,  1], [ 0, 1, 0], [ 1, 1, 0], [ 0, 0,  1]]])
 
     # Laue group : -31M
     if Laue_class == '-31m':
-        print('Laue class : -31m (hex)', unit_cell)
+        logger.debug('Laue class : -31m (hex) %s'%unit_cell)
         if unit_cell[4]==unit_cell[5]:
-            print('#############################################################')
-            print('# Are you using a rhombohedral cell in a hexagonal setting? #')
-            print('#############################################################')
+            logger.debug('#############################################################')
+            logger.debug('# Are you using a rhombohedral cell in a hexagonal setting? #')
+            logger.debug('#############################################################')
         segm = n.array([[[ 0, 0,  0], [ 1, 0, 0], [ 1, 1, 0], [ 0, 0,  1]],
                         [[ 1, 1, -1], [ 1, 0, 0], [ 1, 1, 0], [ 0, 0, -1]]])
 
     # Laue group : -3
     if Laue_class == '-3' and cell_choice!='rhombohedral':
-        print('Laue class : -3 (hex)', unit_cell)
+        logger.debug('Laue class : -3 (hex) %s'%unit_cell)
         if unit_cell[4]==unit_cell[5]:
-            print('#############################################################')
-            print('# Are you using a rhombohedral cell in a hexagonal setting? #')
-            print('#############################################################')
+            logger.debug('#############################################################')
+            logger.debug('# Are you using a rhombohedral cell in a hexagonal setting? #')
+            logger.debug('#############################################################')
         segm = n.array([[[ 0, 0,  0], [ 1, 0, 0], [ 1, 1, 0], [ 0, 0,  1]],
                         [[ 1, 2,  0], [ 1, 1, 0], [ 0, 1, 0], [ 0, 0,  1]],
                         [[ 0, 1,  1], [ 0, 1, 0], [-1, 1, 0], [ 0, 0,  1]]])
@@ -1209,21 +1211,21 @@ def genhkl_base(unit_cell, sysconditions, sintlmin, sintlmax, crystal_system='tr
     # RHOMBOHEDRAL
     # Laue group : -3M
     if Laue_class == '-3m' and cell_choice=='rhombohedral':
-        print('Laue class : -3m (Rhom)', unit_cell)
+        logger.debug('Laue class : -3m (Rhom) %s'%unit_cell)
         if unit_cell[4]!=unit_cell[5]:
-            print('#############################################################')
-            print('# Are you using a hexagonal cell in a rhombohedral setting? #')
-            print('#############################################################')
+            logger.debug('#############################################################')
+            logger.debug('# Are you using a hexagonal cell in a rhombohedral setting? #')
+            logger.debug('#############################################################')
         segm = n.array([[[ 0, 0,  0], [ 1, 0, 0], [ 1, 0,-1], [ 1, 1,  1]],
                         [[ 1, 1,  0], [ 1, 0,-1], [ 0, 0,-1], [ 1, 1,  1]]])
 
     # Laue group : -3
     if Laue_class == '-3' and cell_choice=='rhombohedral':
-        print('Laue class : -3 (Rhom)', unit_cell)
+        logger.debug('Laue class : -3 (Rhom) %s'%unit_cell)
         if unit_cell[4]!=unit_cell[5]:
-            print('#############################################################')
-            print('# Are you using a hexagonal cell in a rhombohedral setting? #')
-            print('#############################################################')
+            logger.debug('#############################################################')
+            logger.debug('# Are you using a hexagonal cell in a rhombohedral setting? #')
+            logger.debug('#############################################################')
         segm = n.array([[[ 0, 0,  0], [ 1, 0, 0], [ 1, 0,-1], [ 1, 1, 1]],
                         [[ 1, 1,  0], [ 1, 0,-1], [ 0, 0,-1], [ 1, 1, 1]],
                         [[ 0,-1, -2], [ 1, 0, 0], [ 1, 0,-1], [-1,-1, -1]],
@@ -1240,7 +1242,7 @@ def genhkl_base(unit_cell, sysconditions, sintlmin, sintlmax, crystal_system='tr
                         [[ 1, 2,  0], [ 0, 1, 0], [ 1, 1, 0], [ 1, 1,  1]]])
 
     if segm is None:
-        print('No Laue class found')
+        logger.debug('No Laue class found')
         return False
 
     nref = 0

--- a/xfab/xfab_logging.py
+++ b/xfab/xfab_logging.py
@@ -1,0 +1,48 @@
+import logging
+
+def get_module_level_logger(module):
+    """Build and set up formatting for a module level logger.
+
+    This is meant to be called in each xfab module as:
+
+        logger = get_module_level_logger(__name__)
+
+    providing a module level logger to use for all local logging.
+
+    The reason for module level loggers is to allow the end user to see what modules produced the logs
+    and give controll over the level of logging. For instance,
+
+        logging.getLogger('xfab.structure').setLevel(CRITICAL)
+
+    will only display logging messages which are errors (or above in severity). Likewise following will shut down
+    logging from xfab.structure completely:
+
+        logging.getLogger('xfab.structure').disabled = True
+
+    Some more logger docs can be found here: https://docs.python.org/3/howto/logging.html#configuring-logging
+
+    Args:
+        module (:obj:`str`): The module name and parents. e.g 'xfab.structure'.
+
+    Returns:
+        (:obj:`logging.logger`) A module level logger.
+
+    """
+    # create logger on lowest level=NOTSET
+    logger = logging.getLogger(module)
+    logger.setLevel(logging.NOTSET)
+
+    # create console handler and set level
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(logging.NOTSET)
+
+    # Some formatting printing what module is logging and the severity etc
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+    # add the formatter to the console handler
+    console_handler.setFormatter(formatter)
+
+    # add the console handler to logger
+    logger.addHandler(console_handler)
+
+    return logger


### PR DESCRIPTION
Make xfab logging module level rather than root such that it is possible to trace and control the logging.

The reason for module level loggers is to allow the end user to see what modules produced the logs
and give controll over the level of logging. For instance,

```python
import logging
logging.getLogger('xfab.structure').setLevel(CRITICAL)
```
will now only display logging messages which are errors (or above in severity). Likewise, the following will shut down
logging from `xfab.structure` completely:
  
```python
import logging
logging.getLogger('xfab.structure').disabled = True
```
As an example of the changes, when doing something like:
```python
import xfab
from xfab import structure
mylist = structure.build_atomlist()
mylist.CIFread('SiO2_mp-7000_conventional_standard.cif')
```
The usual output now specifies the module as
```
2022-01-28 11:45:05,092 - xfab.structure - WARNING - No _atom_type_symbol found in CIF
2022-01-28 11:45:05,092 - xfab.structure - WARNING - No dispersion factors for Si in cif file - set to zero
2022-01-28 11:45:05,094 - xfab.structure - WARNING - No dispersion factors for Si in cif file - set to zero
...
2022-01-28 11:45:05,105 - xfab.structure - WARNING - No dispersion factors for O in cif file - set to zero
2022-01-28 11:45:05,107 - xfab.structure - WARNING - No dispersion factors for O in cif file - set to zero
```
And if we go
```python
import logging
logger = logging.getLogger('xfab.structure')
logger.setLevel(logging.CRITICAL)
```
No output will be written in the above case.