### PR TITLE
Fix xfab checks package level persistent variable

### DIFF
--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -1,0 +1,27 @@
+import numpy as np
+import xfab
+from xfab import tools
+import unittest
+
+
+class test_checks(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(87)
+
+    def test_default_activated(self):
+        tools.u_to_euler(np.random.rand(3, 3))
+
+    def test_deactivate(self):
+        xfab.CHECKS.activated = False
+        tools.u_to_euler(np.random.rand(3, 3))
+
+    def test_reactivate(self):
+        xfab.CHECKS.activated = True
+        try:
+            tools.u_to_euler(np.random.rand(3, 3))
+        except ValueError as e:
+            self.assertEqual(str(e), "orientation matrix U is not unitary, np.dot(U.T, U)!=np.eye(3,3)")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/xfab/__init__.py
+++ b/xfab/__init__.py
@@ -30,3 +30,12 @@ xfab is a library of data and functions for use in Crystallographic computations
 # even if advised of the possibility of such.
 
 
+"""Set a package wide global variable that toogle input/output on functions.
+Checks are on by default. Toogling of checks can be achived as:
+
+    import xfab
+    xfab.CHECKS.activated = False
+
+"""
+from xfab.checks import _checkState
+CHECKS = _checkState()

--- a/xfab/checks.py
+++ b/xfab/checks.py
@@ -1,46 +1,14 @@
-import numpy as np
 
 """The checks module implements input checks for various xfab functions. These checks
-are meant to be called upon during runtime to catch errors made on the user side. The checks 
-module is in its default mode active, however, by toogling a module level variable all check 
-across xfab can be easily turned on or of. This allows users to in some specific scenarios 
-speed up their codes. Furthermore, if __debug__==False all checks are inactivated, i.e
-using python -O to run codes will remove any checks. Example usage
+are meant to be called upon during runtime to catch errors made on the user side. To
+toogle checks in xfab a package wide constant CHECKS defined in the __init__.py should
+be accessed as:
 
 import xfab
-
-xfab.checks.is_activated()
-
-out: True
-
-xfab.off()
-xfab.checks.is_activated()
-
-out: False
-
-xfab.on()
-xfab.checks.is_activated()
-
-out: True
+xfab.CHECKS.activated = False
 
 """
-
-_verify = True
-
-def on(): 
-    """Turn on flag indicating if checks on input and output from xfab functions should be run.
-    """
-    _verify = True
-
-def off(): 
-    """Turn off flag indicating if checks on input and output from xfab functions should be run.
-    """
-    _verify = False
-
-def is_activated():
-    """Return True if checks are to be run.
-    """
-    return _verify and __debug__
+import numpy as np
 
 def _check_rotation_matrix(U):
     """Verify that a 3 x 3 matrix is a rotation matrix.
@@ -70,3 +38,27 @@ def _check_euler_angles(phi1, PHI, phi2):
 
     if not (0<=phi2<=np.pi*2):
         raise ValueError("Euler angle phi2="+str(phi2)+" is not in range [0,2*pi]")
+
+class _checkState(object):
+
+    """A checkState object can be used to determine if checks are active in xfab
+        The default mode is active and can be togled. This allows users to in some
+        specific scenarios speed up their codes. Furthermore, if __debug__==False
+        all checks are inactivated, i.e using python -O to run codes will remove 
+        any checks.
+    """
+    def __init__(self):
+        self._run_checks = True
+
+    @property
+    def activated(self):
+        """True if checks are to be run.
+        """
+        return self._run_checks and __debug__
+
+    @activated.setter
+    def activated(self, value):
+        if value is not True and value is not False:
+            raise ValueError("Please supply a boolean True or False")
+        else:
+            self._run_checks = value

--- a/xfab/symmetry.py
+++ b/xfab/symmetry.py
@@ -8,8 +8,9 @@ from __future__ import print_function
 from xfab import tools
 from six.moves import range
 import numpy as np
-from xfab import xfab_logging
 from xfab import checks
+from xfab import CHECKS
+from xfab import xfab_logging
 logger = xfab_logging.get_module_level_logger(__name__)
 
 
@@ -34,7 +35,7 @@ def Umis(umat_1, umat_2, crystal_system):
             ``shape=(N,2)``.
 
     """
-    if checks.is_activated():
+    if CHECKS.activated:
         checks._check_rotation_matrix(umat_1)
         checks._check_rotation_matrix(umat_2)
 

--- a/xfab/tools.py
+++ b/xfab/tools.py
@@ -9,7 +9,7 @@ import numpy as n
 from math import degrees
 from six.moves import range
 from xfab import checks
-
+from xfab import CHECKS
 from xfab import xfab_logging
 logger = xfab_logging.get_module_level_logger(__name__)
 
@@ -420,7 +420,7 @@ def ubi_to_u(ubi):
     unit_cell = ubi_to_cell(ubi)
     B = form_b_mat(unit_cell)
     U = n.transpose(n.dot(B, ubi))/(2*n.pi)
-    if checks.is_activated(): checks._check_rotation_matrix(U)
+    if CHECKS.activated: checks._check_rotation_matrix(U)
 
     return U
         
@@ -442,7 +442,7 @@ def ubi_to_u_and_eps(ubi,unit_cell):
     B_ubi = form_b_mat(unit_cell_ubi)
     U = n.transpose(n.dot(B_ubi, ubi))/(2*n.pi)
 
-    if checks.is_activated(): checks._check_rotation_matrix(U)
+    if CHECKS.activated: checks._check_rotation_matrix(U)
 
     eps = b_to_epsilon(B_ubi, unit_cell)
     
@@ -614,7 +614,7 @@ def euler_to_u(phi1, PHI, phi2):
     Origingal MATLAB code from: Henning Poulsen, Risoe 15/6 2002.
     
     """
-    if checks.is_activated(): checks._check_euler_angles(phi1, PHI, phi2)
+    if CHECKS.activated: checks._check_euler_angles(phi1, PHI, phi2)
 
     U = n.zeros((3, 3))
     U[0, 0] =   n.cos(phi1)*n.cos(phi2)-n.sin(phi1)*n.sin(phi2)*n.cos(PHI)
@@ -666,7 +666,7 @@ def u_to_euler(U):
 
         Last Modified: Axel Henningsson, January 2021
     """
-    if checks.is_activated(): checks._check_rotation_matrix(U)
+    if CHECKS.activated: checks._check_rotation_matrix(U)
 
     tol = 1e-8
     PHI = n.arccos(U[2, 2])
@@ -718,7 +718,7 @@ def u_to_rod(U):
 
     Function taken from GrainsSpotter by Soeren Schmidt
     """
-    if checks.is_activated(): checks._check_rotation_matrix(U)
+    if CHECKS.activated: checks._check_rotation_matrix(U)
 
     ttt = 1+U[0, 0]+U[1, 1]+U[2, 2]
     if abs(ttt) < 1e-16: 
@@ -736,7 +736,7 @@ def u_to_ubi(u_mat,unit_cell):
     OUTPUT: UBI 3x3 matrix
 
     """
-    if checks.is_activated(): checks._check_rotation_matrix(u_mat)
+    if CHECKS.activated: checks._check_rotation_matrix(u_mat)
 
     b_mat = form_b_mat(unit_cell)
     
@@ -819,7 +819,7 @@ def ub_to_u_b(UB):
         U[1, 2] = -U[1, 2]
         U[2, 2] = -U[2, 2]
 
-    if checks.is_activated(): checks._check_rotation_matrix(U)
+    if CHECKS.activated: checks._check_rotation_matrix(U)
 
     return (U, B)
 


### PR DESCRIPTION
The `xfab.checks` was meant to implement a package level boolean that could be used to determine if additional input/output checks should be run in various module level functions. This pull requests fixes bugs to make this the expected behaviour of `xfab`.

Essentially it is necessary to have such a boolean constant (named `CHECKS`) defined in the `__init__.py` rather than in the `xfab.checks` module.

This pull request does not change any functionality of `xfab` except that the syntax to toogle checks in `xfab` has become slightly simplified. By default:

```python
import xfab
print(xfab.CHECKS.activated)

OUT: >> True
```
To toggle, simply go:
```python
xfab.CHECKS.activated = False
```