### PR TITLE
Move copyright and license to dedicated LICENSE.txt file

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,26 @@
+# Copyright (c) 2008, Henning Osholm Sorensen, Riso National Laboratory,
+# Technical University of Denmark, DK-4000 Roskilde, Denmark
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+
+#  -  Redistributions of source code must retain the above copyright notice, this
+#     list of con-ditions and the following disclaimer.
+#  -  Redistributions in binary form must reproduce the above copyright notice, this
+#     list of conditions and the following disclaimer in the documentation and/or
+#     other materials provided with the distribution.
+#  -  Neither the name of the Riso National Laboratory nor the names of its
+#     contributors may be used to endorse or promote products derived from this
+#     software without specific prior written permission.
+
+# This software is provided by the copyright holders and contributors "AS IS" and
+# any express or implied warranties, including, but not limited to, the implied
+# warranties of merchantability and fitness for a particular purpose are
+# disclaimed. In no event shall the copyright owner or contributors be liable for
+# any direct, indirect incidential, special, exemplary, or consequential damages
+# (including but not limited to, procurement of substitute goods or services, loss
+# of use, data or profits or business interruption) however caused and on any
+# theory of liability, whether in contract, strict liability or tort (including
+# negligence or otherwise) arising in any way out of the use of this software,
+# even if advised of the possibility of such.

--- a/xfab/__init__.py
+++ b/xfab/__init__.py
@@ -2,33 +2,6 @@
 xfab is a library of data and functions for use in Crystallographic computations. xfab is part of the project fable: http://fable.wiki.sourceforge.net
 """
 
-# Copyright (c) 2008, Henning Osholm Sorensen, Riso National Laboratory,
-# Technical University of Denmark, DK-4000 Roskilde, Denmark
-# All rights reserved.
-
-# Redistribution and use in source and binary forms, with or without modification,
-# are permitted provided that the following conditions are met:
-
-#  -  Redistributions of source code must retain the above copyright notice, this
-#     list of con-ditions and the following disclaimer.  
-#  -  Redistributions in binary form must reproduce the above copyright notice, this
-#     list of conditions and the following disclaimer in the documentation and/or
-#     other materials provided with the distribution.  
-#  -  Neither the name of the Riso National Laboratory nor the names of its
-#     contributors may be used to endorse or promote products derived from this
-#     software without specific prior written permission. 
-        
-# This software is provided by the copyright holders and contributors "AS IS" and
-# any express or implied warranties, including, but not limited to, the implied
-# warranties of merchantability and fitness for a particular purpose are
-# disclaimed. In no event shall the copyright owner or contributors be liable for
-# any direct, indirect incidential, special, exemplary, or consequential damages
-# (including but not limited to, procurement of substitute goods or services, loss
-# of use, data or profits or business interruption) however caused and on any
-# theory of liability, whether in contract, strict liability or tort (including
-# negligence or otherwise) arising in any way out of the use of this software,
-# even if advised of the possibility of such.
-
 
 """Set a package wide global variable that toogle input/output on functions.
 Checks are on by default. Toogling of checks can be achived as:


### PR DESCRIPTION
Move copyright and license to dedicated LICENSE.txt file as is [common and best practice for python packaging](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#license-txt).

**NOTE:** This pull request does not in any way modify, change or alter the copyright and license statements as previously found in the `__init__.py`, nor is it the intent or purpose of the author to do so.