### PR TITLE
updates to xfab.tools.ubi_to_cell to follow 2*pi convention

### DIFF
--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -150,6 +150,15 @@ class test_twotheta(unittest.TestCase):
         diff = n.abs(tth-tth2)
         self.assertAlmostEqual(diff,0,9)
         
+class test_ubi_to_cell(unittest.TestCase):
+    def test1(self):
+        unit_cell_1  =  [2., 3., 4., 90.,90.,120.]
+        B = tools.form_b_mat(unit_cell_1)
+        U = n.eye(3, 3, dtype=n.float64)
+        ubi = n.linalg.inv( U.dot(B) )
+        unit_cell_2 = tools.ubi_to_cell(ubi)
+        for c1,c2 in zip(unit_cell_1, unit_cell_2):
+            self.assertAlmostEqual( c1, c2, msg='unit cell is not preserved over B matrix cycling')
 
 class test_general_orientation(unittest.TestCase):
 

--- a/xfab/tools.py
+++ b/xfab/tools.py
@@ -403,8 +403,8 @@ def ubi_to_cell(ubi_matrix):
     returns unit_cell = [a, b, c, alpha, beta, gamma] 
     
     """
-    ubi = n.asarray(ubi_matrix, float)
-    return n.array(a_to_cell(n.transpose(ubi)))
+    ubi = n.asarray(ubi_matrix * 2 * n.pi, float)
+    return n.array(a_to_cell( n.transpose(ubi) ))
         
 def ubi_to_u(ubi_matrix):
     """
@@ -422,7 +422,7 @@ def ubi_to_u(ubi_matrix):
     if CHECKS.activated: checks._check_ubi_matrix(ubi)
     unit_cell = ubi_to_cell(ubi)
     B = form_b_mat(unit_cell)
-    U = n.transpose(n.dot(B, ubi))/(2*n.pi)
+    U = n.transpose(n.dot(B, ubi))
 
     return U
         
@@ -442,7 +442,7 @@ def ubi_to_u_and_eps(ubi_matrix,unit_cell):
     ubi = n.asarray(ubi_matrix, float)
     deformed_unit_cell = ubi_to_cell(ubi)
     B_deformed = form_b_mat(deformed_unit_cell)
-    U = n.transpose(n.dot(B_deformed, ubi))/(2*n.pi)
+    U = n.transpose(n.dot(B_deformed, ubi))
 
     if CHECKS.activated: checks._check_rotation_matrix(U)
 


### PR DESCRIPTION
Fix `xfab.tools.ubi_to_cell` to follow the 2pi convention and preserve unit cells between calls to `xfab.tools.form_b_mat` and `xfab.tools.ubi_to_cell`.
